### PR TITLE
RDK-30145: correcting comment in XML protocol

### DIFF
--- a/extensions/RdkShellExtendedInput/protocol/rdkshell_extended_input.xml
+++ b/extensions/RdkShellExtendedInput/protocol/rdkshell_extended_input.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     If not stated otherwise in this file or this component's LICENSE
     file the following copyright and licenses apply:
@@ -16,7 +17,6 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <protocol name="rdkshell_extended_input">
 
     <copyright>


### PR DESCRIPTION
Reason for change: comment incorrectly placed and fails in wayland-scanner.
Risks: Low
Test Procedure: works in wayland-scanner.

Signed-off-by: Justin Ware <justin.ware@sky.uk>