### PR TITLE
Wayland Display: Enabling Wayland display based on Environment Variable

### DIFF
--- a/compositorcontroller.cpp
+++ b/compositorcontroller.cpp
@@ -1133,6 +1133,7 @@ namespace RdkShell
                 gSplashImage->draw();
             }
         }
+        return true;
     }
 
     bool CompositorController::addAnimation(const std::string& client, double duration, std::map<std::string, RdkShellData> &animationProperties)

--- a/rdkshell.cpp
+++ b/rdkshell.cpp
@@ -297,8 +297,10 @@ namespace RdkShell
 
         bool isWayland = false;
         char const *disp = getenv("WAYLAND_DISPLAY");
-        if (disp != 0) {
-                isWayland = true; }	
+        if (disp != 0)
+        {
+                isWayland = true;
+        }	
         #ifdef RDKSHELL_ENABLE_FORCE_1080
         std::ifstream file720("/tmp/rdkshell720");
         if (file720.good())

--- a/rdkshell.cpp
+++ b/rdkshell.cpp
@@ -295,25 +295,25 @@ namespace RdkShell
         }
         #endif
 
-        bool Iswayland = false;
+        bool isWayland = false;
         char const *disp = getenv("WAYLAND_DISPLAY");
         if (disp != 0) {
-                Iswayland = true; }	
+                isWayland = true; }	
         #ifdef RDKSHELL_ENABLE_FORCE_1080
         std::ifstream file720("/tmp/rdkshell720");
         if (file720.good())
         {
             std::cout << "!!!!! forcing 720 start!\n";
-            RdkShell::EssosInstance::instance()->initialize(Iswayland, 1280, 720);
+            RdkShell::EssosInstance::instance()->initialize(isWayland, 1280, 720);
             gForce720 = true;
         }
         else
         {
             std::cout << "!!!!! forcing 1080 start!\n";
-            RdkShell::EssosInstance::instance()->initialize(Iswayland, 1920, 1080);
+            RdkShell::EssosInstance::instance()->initialize(isWayland, 1920, 1080);
         }
         #else
-        RdkShell::EssosInstance::instance()->initialize(Iswayland);
+        RdkShell::EssosInstance::instance()->initialize(isWayland);
         #endif //RDKSHELL_ENABLE_FORCE_1080
         glEnable(GL_BLEND);
         glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);

--- a/rdkshell.cpp
+++ b/rdkshell.cpp
@@ -295,21 +295,25 @@ namespace RdkShell
         }
         #endif
 
+        bool Iswayland = false;
+        char const *disp = getenv("WAYLAND_DISPLAY");
+        if (disp != 0) {
+                Iswayland = true; }	
         #ifdef RDKSHELL_ENABLE_FORCE_1080
         std::ifstream file720("/tmp/rdkshell720");
         if (file720.good())
         {
             std::cout << "!!!!! forcing 720 start!\n";
-            RdkShell::EssosInstance::instance()->initialize(false, 1280, 720);
+            RdkShell::EssosInstance::instance()->initialize(Iswayland, 1280, 720);
             gForce720 = true;
         }
         else
         {
             std::cout << "!!!!! forcing 1080 start!\n";
-            RdkShell::EssosInstance::instance()->initialize(false, 1920, 1080);
+            RdkShell::EssosInstance::instance()->initialize(Iswayland, 1920, 1080);
         }
         #else
-        RdkShell::EssosInstance::instance()->initialize(false);
+        RdkShell::EssosInstance::instance()->initialize(Iswayland);
         #endif //RDKSHELL_ENABLE_FORCE_1080
         glEnable(GL_BLEND);
         glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);


### PR DESCRIPTION
Adding return to bool resolves the rdkshell crash issue when compiled
with gcc 9.0 or higher.#54
Enabling wayland display when environment variable WAYLAND_DISPLAY is
set otherwise it will use direct.

Signed-off-by: Balaji Velmurugan <balaji_velmurugan@ltts.com>