### PR TITLE
compositorcontroller: fix for -Wreturn-type error

### DIFF
--- a/compositorcontroller.cpp
+++ b/compositorcontroller.cpp
@@ -1140,6 +1140,7 @@ namespace RdkShell
                 gSplashImage->draw();
             }
         }
+	return true;
     }
 
     bool CompositorController::addAnimation(const std::string& client, double duration, std::map<std::string, RdkShellData> &animationProperties)

--- a/servermessagehandler.cpp
+++ b/servermessagehandler.cpp
@@ -204,6 +204,7 @@ namespace RdkShell
         {
             ((ServerMessageHandler*)context)->communicationHandler()->sendMessage(id,message);
         }
+        return true;
     }
   
     bool getScaleHandler(int id, const rapidjson::Value& params, void* context)


### PR DESCRIPTION
fix for #54 rdkshell crash when built from gcc 9.x or higher

return statement of CompositorController::draw() is missed
as its return type is bool. Upon having a return type but
no return value, rdkshell encounters segmentation fault while
building it on higher version of gcc

Signed-off-by: Moorthy Baskar <moorthy.bs@ltts.com>