### PR TITLE
RDKTV-13534 : Wpeframework service failed and restarted when VirtualD…

### DIFF
--- a/framebuffer.cpp
+++ b/framebuffer.cpp
@@ -66,12 +66,12 @@ namespace RdkShell
         glDeleteTextures(1, &mTextureId);
     }
 
-    bool FrameBuffer::bind()
+    void FrameBuffer::bind()
     {
         glBindFramebuffer(GL_FRAMEBUFFER, mFboId);
     }
 
-    bool FrameBuffer::unbind()
+    void FrameBuffer::unbind()
     {
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
     }

--- a/framebuffer.h
+++ b/framebuffer.h
@@ -34,8 +34,8 @@ namespace RdkShell
 
         GLuint texture() const { return mTextureId; }
 
-        bool bind();
-        bool unbind();
+        void bind();
+        void unbind();
 
     private:
         int mWidth;


### PR DESCRIPTION
…isplay is enabled, storageMgrMain crashed

Reason for change: causing crash.
Test Procedure: sanity test
Risks: None
Signed-off-by: Neeraj_Sahu@comcast.com