### PR TITLE
DELIA-52333: [TDK]Some of the RDKShell events are not getting triggered

### DIFF
--- a/compositorcontroller.cpp
+++ b/compositorcontroller.cpp
@@ -149,7 +149,10 @@ namespace RdkShell
         size_t found = stdClientName.find(str1);
         if (found != std::string::npos)
         {
-          stdClientName.erase(0,4);
+          if((stdClientName.compare(0, 4, str1)) == 0)
+          {
+            stdClientName.erase(0,4);
+	  }
         }
         for (auto it = gCompositorList.begin(); it != gCompositorList.end(); ++it)
         {


### PR DESCRIPTION
From: kchinn681 <kathiravan_chinnadurai@comcast.com>

Subject: [TDK]Some of the RDKShell events are not getting triggered
Reason for change: curl command support for rs
Test Procedure: Enable and disable rdkshell events from curl command and see events are triggered in the logs
Risks: Low
Signed-off-by: kathiravan chinnadurai <kathiravan_chinnadurai@comcast.com>
Source: COMCAST
License: GPLV2
Upstream-Status: Pending