### PR TITLE
RDK-35488:REFPLTV-1215: Unable to play the Next video content on CNN

### DIFF
--- a/compositorcontroller.cpp
+++ b/compositorcontroller.cpp
@@ -1591,9 +1591,6 @@ namespace RdkShell
 
     bool CompositorController::onEvent(RdkCompositor* eventCompositor, const std::string& eventName)
     {
-        bool killClient = false;
-        std::string clientToKill("");
-
         CompositorListIterator it;
         if (getCompositorInfo(eventCompositor, it))
         {
@@ -1601,15 +1598,6 @@ namespace RdkShell
             {
                 sendApplicationEvent(it->eventListeners[i], eventName, it->name);
             }
-            if ((gRdkShellCompositorType == SURFACE) && (eventName.compare(RDKSHELL_EVENT_APPLICATION_DISCONNECTED) == 0))
-            {
-                clientToKill = it->name;
-                killClient = true;
-            }
-        }
-        if (true == killClient)
-        {
-            CompositorController::kill(clientToKill);
         }
         return true;
     }


### PR DESCRIPTION
Playback on any next video in CNN/Youtube ... results in black screen.

Reason for change: On Surface disconnect event, kills the client with surface compositor.
Test Procedure: Playback of next video should work.
Risks: None