### PR TITLE
RDK-35488:Issues in CMF-RPi Dunfell Builds when "RDKSHELL_COMPOSITOR_…

### DIFF
--- a/compositorcontroller.cpp
+++ b/compositorcontroller.cpp
@@ -1601,11 +1601,20 @@ namespace RdkShell
             {
                 sendApplicationEvent(it->eventListeners[i], eventName, it->name);
             }
-            if ((gRdkShellCompositorType == SURFACE) && (eventName.compare(RDKSHELL_EVENT_APPLICATION_DISCONNECTED) == 0))
+	    if((gRdkShellCompositorType == SURFACE) && (eventName.compare(RDKSHELL_EVENT_APPLICATION_CONNECTED) == 0))
             {
-                clientToKill = it->name;
-                killClient = true;
+               it->compositor->mSurfaceCount++; 
             }
+	    else if ((gRdkShellCompositorType == SURFACE) && (eventName.compare(RDKSHELL_EVENT_APPLICATION_DISCONNECTED) == 0))
+            {
+		it->compositor->mSurfaceCount--;
+		if(it->compositor->mSurfaceCount == 0)
+                {
+                  clientToKill = it->name;
+                  killClient = true;
+	        }
+            }
+	    else {}
         }
         if (true == killClient)
         {

--- a/compositorcontroller.cpp
+++ b/compositorcontroller.cpp
@@ -56,13 +56,12 @@ namespace RdkShell
 
     struct CompositorInfo
     {
-        CompositorInfo() : name(), compositor(nullptr), eventListeners(), mimeType() , autoDestory(false) {}
+        CompositorInfo() : name(), compositor(nullptr), eventListeners(), mimeType() {}
         std::string name;
         std::shared_ptr<RdkCompositor> compositor;
         std::map<uint32_t, std::vector<KeyListenerInfo>> keyListenerInfo;
         std::vector<std::shared_ptr<RdkShellEventListener>> eventListeners;
         std::string mimeType;
-	bool autoDestory;
     };
 
     struct KeyInterceptInfo
@@ -1610,7 +1609,7 @@ namespace RdkShell
             {
 		it->compositor->updateSurfaceCount(false);
 		bool gSurfaceCount = it->compositor->getSurfaceCount();
-		if((gSurfaceCount == 0) && (it->autoDestory == true))
+		if(gSurfaceCount == 0)
                 {
                   clientToKill = it->name;
                   killClient = true;
@@ -1653,7 +1652,7 @@ namespace RdkShell
     }
 
     bool CompositorController::launchApplication(const std::string& client, const std::string& uri, const std::string& mimeType,
-        bool topmost, bool focus, bool autodestory)
+        bool topmost, bool focus)
     {
         if (mimeType == RDKSHELL_APPLICATION_MIME_TYPE_NATIVE)
         {
@@ -1666,7 +1665,6 @@ namespace RdkShell
             std::string clientDisplayName = standardizeName(client);
             CompositorInfo compositorInfo;
             compositorInfo.name = clientDisplayName;
-	    compositorInfo.autoDestory = autodestory;
             if (gRdkShellCompositorType == SURFACE)
             {
                 compositorInfo.compositor = std::make_shared<RdkCompositorSurface>();

--- a/compositorcontroller.cpp
+++ b/compositorcontroller.cpp
@@ -1608,8 +1608,8 @@ namespace RdkShell
 	    else if ((gRdkShellCompositorType == SURFACE) && (eventName.compare(RDKSHELL_EVENT_APPLICATION_DISCONNECTED) == 0))
             {
 		it->compositor->updateSurfaceCount(false);
-		bool gSurfaceCount = it->compositor->getSurfaceCount();
-		if(gSurfaceCount == 0)
+		bool SurfaceCount = it->compositor->getSurfaceCount();
+		if(SurfaceCount == 0)
                 {
                   clientToKill = it->name;
                   killClient = true;

--- a/compositorcontroller.h
+++ b/compositorcontroller.h
@@ -84,7 +84,7 @@ namespace RdkShell
             static double getInactivityTimeInMinutes();
             static void setEventListener(std::shared_ptr<RdkShellEventListener> listener);
             static std::shared_ptr<RdkCompositor> getCompositor(const std::string& displayName);
-            static bool launchApplication(const std::string& client, const std::string& uri, const std::string& mimeType, bool topmost = false, bool focus = false);
+            static bool launchApplication(const std::string& client, const std::string& uri, const std::string& mimeType, bool topmost = false, bool focus = false,bool autodestory = false);
             static bool suspendApplication(const std::string& client);
             static bool resumeApplication(const std::string& client);
             static bool closeApplication(const std::string& client);

--- a/compositorcontroller.h
+++ b/compositorcontroller.h
@@ -84,7 +84,7 @@ namespace RdkShell
             static double getInactivityTimeInMinutes();
             static void setEventListener(std::shared_ptr<RdkShellEventListener> listener);
             static std::shared_ptr<RdkCompositor> getCompositor(const std::string& displayName);
-            static bool launchApplication(const std::string& client, const std::string& uri, const std::string& mimeType, bool topmost = false, bool focus = false,bool autodestory = false);
+            static bool launchApplication(const std::string& client, const std::string& uri, const std::string& mimeType, bool topmost = false, bool focus = false );
             static bool suspendApplication(const std::string& client);
             static bool resumeApplication(const std::string& client);
             static bool closeApplication(const std::string& client);

--- a/compositorcontroller.h
+++ b/compositorcontroller.h
@@ -84,7 +84,7 @@ namespace RdkShell
             static double getInactivityTimeInMinutes();
             static void setEventListener(std::shared_ptr<RdkShellEventListener> listener);
             static std::shared_ptr<RdkCompositor> getCompositor(const std::string& displayName);
-            static bool launchApplication(const std::string& client, const std::string& uri, const std::string& mimeType, bool topmost = false, bool focus = false );
+            static bool launchApplication(const std::string& client, const std::string& uri, const std::string& mimeType, bool topmost = false, bool focus = false);
             static bool suspendApplication(const std::string& client);
             static bool resumeApplication(const std::string& client);
             static bool closeApplication(const std::string& client);

--- a/rdkcompositor.cpp
+++ b/rdkcompositor.cpp
@@ -50,7 +50,7 @@ namespace RdkShell
         mVisible(true), mAnimating(false), mHolePunch(true), mScaleX(1.0), mScaleY(1.0), mEnableKeyMetadata(false), mInputListenerTags(RDKSHELL_INITIAL_INPUT_LISTENER_TAG), mInputLock(), mInputListeners(),
         mApplicationName(), mApplicationThread(), mApplicationState(RdkShell::ApplicationState::Unknown),
         mApplicationPid(-1), mApplicationThreadStarted(false), mApplicationClosedByCompositor(false), mApplicationMutex(), mReceivedKeyPress(false),
-        mVirtualDisplayEnabled(false), mVirtualWidth(0), mVirtualHeight(0), mSizeChangeRequestPresent(false) , mSurfaceCount(false) 
+        mVirtualDisplayEnabled(false), mVirtualWidth(0), mVirtualHeight(0), mSizeChangeRequestPresent(false) , mSurfaceCount(0) 
     {
         if (gForce720)
         {

--- a/rdkcompositor.cpp
+++ b/rdkcompositor.cpp
@@ -50,7 +50,7 @@ namespace RdkShell
         mVisible(true), mAnimating(false), mHolePunch(true), mScaleX(1.0), mScaleY(1.0), mEnableKeyMetadata(false), mInputListenerTags(RDKSHELL_INITIAL_INPUT_LISTENER_TAG), mInputLock(), mInputListeners(),
         mApplicationName(), mApplicationThread(), mApplicationState(RdkShell::ApplicationState::Unknown),
         mApplicationPid(-1), mApplicationThreadStarted(false), mApplicationClosedByCompositor(false), mApplicationMutex(), mReceivedKeyPress(false),
-        mVirtualDisplayEnabled(false), mVirtualWidth(0), mVirtualHeight(0), mSizeChangeRequestPresent(false)
+        mVirtualDisplayEnabled(false), mVirtualWidth(0), mVirtualHeight(0), mSizeChangeRequestPresent(false) , mSurfaceCount(false) 
     {
         if (gForce720)
         {
@@ -653,4 +653,20 @@ namespace RdkShell
         return mVirtualDisplayEnabled;
     }
 
+    void RdkCompositor::updateSurfaceCount (bool status)
+     {
+        if(status == true)
+        {
+	  mSurfaceCount++;
+	}
+	else if ((status == false) && ( mSurfaceCount > 0))
+	{
+          mSurfaceCount--;
+        } 
+     }
+
+     uint32_t RdkCompositor::getSurfaceCount (void)
+     {
+        return mSurfaceCount;
+     }
 }

--- a/rdkcompositor.h
+++ b/rdkcompositor.h
@@ -74,6 +74,7 @@ namespace RdkShell
             void setVirtualResolution(uint32_t virtualWidth, uint32_t virtualHeight);
             void enableVirtualDisplay(bool enable);
             bool getVirtualDisplayEnabled();
+	    uint32_t mSurfaceCount=0;
 
         private:
             void prepareHolePunchRects(std::vector<WstRect> wstrects, RdkShellRect& rect);

--- a/rdkcompositor.h
+++ b/rdkcompositor.h
@@ -73,12 +73,13 @@ namespace RdkShell
             void getVirtualResolution(uint32_t &virtualWidth, uint32_t &virtualHeight);
             void setVirtualResolution(uint32_t virtualWidth, uint32_t virtualHeight);
             void enableVirtualDisplay(bool enable);
-            bool getVirtualDisplayEnabled();
-	    uint32_t mSurfaceCount=0;
+	    bool getVirtualDisplayEnabled();
+	    void updateSurfaceCount(bool status);
+	    uint32_t getSurfaceCount(void); 
 
         private:
             void prepareHolePunchRects(std::vector<WstRect> wstrects, RdkShellRect& rect);
-
+            uint32_t mSurfaceCount;
         protected:
             static void invalidate(WstCompositor *context, void *userData);
             static void clientStatus(WstCompositor *context, int status, int pid, int detail, void *userData);


### PR DESCRIPTION
…TYPE" is set to "surface"

From: kchinn681 <kathiravan_chinnadurai@comcast.com>

Subject: issues in CMF-RPi Dunfell Builds when "RDKSHELL_COMPOSITOR_TYPE" is set to "surface"
Reason for change: to handle multiple rendering in surface mode
Test Procedure: to launch cnn app , run any video and see cnn  app is exiting
Risks: Low
Signed-off-by: kathiravan chinnadurai <kathiravan_chinnadurai@comcast.com>
Source: COMCAST
License: GPLV2
Upstream-Status: Pending