### PR TITLE
RDK-35488:Issues in CMF-RPi Dunfell Builds when "RDKSHELL_COMPOSITOR_…

### DIFF
--- a/compositorcontroller.cpp
+++ b/compositorcontroller.cpp
@@ -1601,10 +1601,19 @@ namespace RdkShell
             {
                 sendApplicationEvent(it->eventListeners[i], eventName, it->name);
             }
-            if ((gRdkShellCompositorType == SURFACE) && (eventName.compare(RDKSHELL_EVENT_APPLICATION_DISCONNECTED) == 0))
+	    if((gRdkShellCompositorType == SURFACE) && (eventName.compare(RDKSHELL_EVENT_APPLICATION_CONNECTED) == 0))
             {
-                clientToKill = it->name;
-                killClient = true;
+		    it->compositor->updateSurfaceCount(true);
+            }
+	    else if ((gRdkShellCompositorType == SURFACE) && (eventName.compare(RDKSHELL_EVENT_APPLICATION_DISCONNECTED) == 0))
+            {
+		it->compositor->updateSurfaceCount(false);
+		bool SurfaceCount = it->compositor->getSurfaceCount();
+		if(SurfaceCount == 0)
+                {
+                  clientToKill = it->name;
+                  killClient = true;
+	        }
             }
         }
         if (true == killClient)

--- a/rdkcompositor.cpp
+++ b/rdkcompositor.cpp
@@ -50,7 +50,7 @@ namespace RdkShell
         mVisible(true), mAnimating(false), mHolePunch(true), mScaleX(1.0), mScaleY(1.0), mEnableKeyMetadata(false), mInputListenerTags(RDKSHELL_INITIAL_INPUT_LISTENER_TAG), mInputLock(), mInputListeners(),
         mApplicationName(), mApplicationThread(), mApplicationState(RdkShell::ApplicationState::Unknown),
         mApplicationPid(-1), mApplicationThreadStarted(false), mApplicationClosedByCompositor(false), mApplicationMutex(), mReceivedKeyPress(false),
-        mVirtualDisplayEnabled(false), mVirtualWidth(0), mVirtualHeight(0), mSizeChangeRequestPresent(false)
+        mVirtualDisplayEnabled(false), mVirtualWidth(0), mVirtualHeight(0), mSizeChangeRequestPresent(false) , mSurfaceCount(0) 
     {
         if (gForce720)
         {
@@ -653,4 +653,20 @@ namespace RdkShell
         return mVirtualDisplayEnabled;
     }
 
+    void RdkCompositor::updateSurfaceCount (bool status)
+     {
+        if(status == true)
+        {
+	  mSurfaceCount++;
+	}
+	else if ((status == false) && ( mSurfaceCount > 0))
+	{
+          mSurfaceCount--;
+        } 
+     }
+
+     uint32_t RdkCompositor::getSurfaceCount (void)
+     {
+        return mSurfaceCount;
+     }
 }

--- a/rdkcompositor.h
+++ b/rdkcompositor.h
@@ -73,11 +73,13 @@ namespace RdkShell
             void getVirtualResolution(uint32_t &virtualWidth, uint32_t &virtualHeight);
             void setVirtualResolution(uint32_t virtualWidth, uint32_t virtualHeight);
             void enableVirtualDisplay(bool enable);
-            bool getVirtualDisplayEnabled();
+	    bool getVirtualDisplayEnabled();
+	    void updateSurfaceCount(bool status);
+	    uint32_t getSurfaceCount(void); 
 
         private:
             void prepareHolePunchRects(std::vector<WstRect> wstrects, RdkShellRect& rect);
-
+            uint32_t mSurfaceCount;
         protected:
             static void invalidate(WstCompositor *context, void *userData);
             static void clientStatus(WstCompositor *context, int status, int pid, int detail, void *userData);


### PR DESCRIPTION
* RDK-35488:Issues in CMF-RPi Dunfell Builds when "RDKSHELL_COMPOSITOR_TYPE" is set to "surface"

From: kchinn681 <kathiravan_chinnadurai@comcast.com>

Subject: issues in CMF-RPi Dunfell Builds when "RDKSHELL_COMPOSITOR_TYPE" is set to "surface"
Reason for change: to handle multiple rendering in surface mode
Test Procedure: to launch cnn app , run any video and see cnn  app is exiting
Risks: Low
Signed-off-by: kathiravan chinnadurai <kathiravan_chinnadurai@comcast.com>
Source: COMCAST
License: GPLV2
Upstream-Status: Pending

* RDK-35488:Issues in CMF-RPi Dunfell Builds when "RDKSHELL_COMPOSITOR_TYPE" is set to "surface"

From: kchinn681 <kathiravan_chinnadurai@comcast.com>

Subject: issues in CMF-RPi Dunfell Builds when "RDKSHELL_COMPOSITOR_TYPE" is set to "surface"
Reason for change: to handle multiple rendering in surface mode
Test Procedure: to launch cnn app , run any video and see cnn  app is exiting
Risks: Low
Signed-off-by: kathiravan chinnadurai <kathiravan_chinnadurai@comcast.com>
Source: COMCAST
License: GPLV2
Upstream-Status: Pending

* RDK-35488:Issues in CMF-RPi Dunfell Builds when "RDKSHELL_COMPOSITOR_TYPE" is set to "surface"

From: kchinn681 <kathiravan_chinnadurai@comcast.com>

Subject: issues in CMF-RPi Dunfell Builds when "RDKSHELL_COMPOSITOR_TYPE" is set to "surface"
Reason for change: to handle multiple rendering in surface mode
Test Procedure: to launch cnn app , run any video and see cnn  app is exiting
Risks: Low
Signed-off-by: kathiravan chinnadurai <kathiravan_chinnadurai@comcast.com>
Source: COMCAST
License: GPLV2
Upstream-Status: Pending

* RDK-35488:Issues in CMF-RPi Dunfell Builds when "RDKSHELL_COMPOSITOR_TYPE" is set to "surface"

From: kchinn681 <kathiravan_chinnadurai@comcast.com>

Subject: issues in CMF-RPi Dunfell Builds when "RDKSHELL_COMPOSITOR_TYPE" is set to "surface"
Reason for change: to handle multiple rendering in surface mode
Test Procedure: to launch cnn app , run any video and see cnn  app is exiting
Risks: Low
Signed-off-by: kathiravan chinnadurai <kathiravan_chinnadurai@comcast.com>
Source: COMCAST
License: GPLV2
Upstream-Status: Pending

* RDK-35488:Issues in CMF-RPi Dunfell Builds when "RDKSHELL_COMPOSITOR_TYPE" is set to "surface"

From: kchinn681 <kathiravan_chinnadurai@comcast.com>

Subject: issues in CMF-RPi Dunfell Builds when "RDKSHELL_COMPOSITOR_TYPE" is set to "surface"
Reason for change: to handle multiple rendering in surface mode
Test Procedure: to launch cnn app , run any video and see cnn  app is exiting
Risks: Low
Signed-off-by: kathiravan chinnadurai <kathiravan_chinnadurai@comcast.com>
Source: COMCAST
License: GPLV2
Upstream-Status: Pending