### PR TITLE
RDK-35488:Issues in CMF-RPi Dunfell Builds when rdkshell in surfacemode

### DIFF
--- a/compositorcontroller.cpp
+++ b/compositorcontroller.cpp
@@ -62,6 +62,7 @@ namespace RdkShell
         std::map<uint32_t, std::vector<KeyListenerInfo>> keyListenerInfo;
         std::vector<std::shared_ptr<RdkShellEventListener>> eventListeners;
         std::string mimeType;
+	bool autoDestroy;
     };
 
     struct KeyInterceptInfo
@@ -1275,7 +1276,7 @@ namespace RdkShell
 
     bool CompositorController::createDisplay(const std::string& client, const std::string& displayName,
         uint32_t displayWidth, uint32_t displayHeight, bool virtualDisplayEnabled, uint32_t virtualWidth, uint32_t virtualHeight,
-        bool topmost, bool focus)
+        bool topmost, bool focus , bool autodestroy)
     {
         Logger::log(LogLevel::Information,
             "rdkshell createDisplay client: %s, displayName: %s, res: %d x %d, virtualDisplayEnabled: %d, virtualRes: %d x %d, topmost: %d, focus: %d\n",
@@ -1297,6 +1298,7 @@ namespace RdkShell
         }
         CompositorInfo compositorInfo;
         compositorInfo.name = clientDisplayName;
+	compositorInfo.autoDestroy = autodestroy;
         if (gRdkShellCompositorType == SURFACE)
         {
             compositorInfo.compositor = std::make_shared<RdkCompositorSurface>();
@@ -1609,7 +1611,8 @@ namespace RdkShell
             {
 		it->compositor->updateSurfaceCount(false);
 		bool SurfaceCount = it->compositor->getSurfaceCount();
-		if(SurfaceCount == 0)
+
+		if((SurfaceCount == 0) && (it->autoDestroy == true ))
                 {
                   clientToKill = it->name;
                   killClient = true;

--- a/compositorcontroller.h
+++ b/compositorcontroller.h
@@ -72,7 +72,7 @@ namespace RdkShell
             static void onKeyPress(uint32_t keycode, uint32_t flags, uint64_t metadata, bool physicalKeyPress=true);
             static void onKeyRelease(uint32_t keycode, uint32_t flags, uint64_t metadata, bool physicalKeyPress=true);
             static bool createDisplay(const std::string& client, const std::string& displayName, uint32_t displayWidth=0, uint32_t displayHeight=0,
-                bool virtualDisplayEnabled=false, uint32_t virtualWidth=0, uint32_t virtualHeight=0, bool topmost = false, bool focus = false);
+                bool virtualDisplayEnabled=false, uint32_t virtualWidth=0, uint32_t virtualHeight=0, bool topmost = false, bool focus = false , bool autodestroy = false);
             static bool addAnimation(const std::string& client, double duration, std::map<std::string, RdkShellData> &animationProperties);
             static bool removeAnimation(const std::string& client);
             static bool addListener(const std::string& client, std::shared_ptr<RdkShellEventListener> listener);

--- a/compositorcontroller.h
+++ b/compositorcontroller.h
@@ -72,7 +72,7 @@ namespace RdkShell
             static void onKeyPress(uint32_t keycode, uint32_t flags, uint64_t metadata, bool physicalKeyPress=true);
             static void onKeyRelease(uint32_t keycode, uint32_t flags, uint64_t metadata, bool physicalKeyPress=true);
             static bool createDisplay(const std::string& client, const std::string& displayName, uint32_t displayWidth=0, uint32_t displayHeight=0,
-                bool virtualDisplayEnabled=false, uint32_t virtualWidth=0, uint32_t virtualHeight=0, bool topmost = false, bool focus = false , bool autodestroy = false);
+                bool virtualDisplayEnabled=false, uint32_t virtualWidth=0, uint32_t virtualHeight=0, bool topmost = false, bool focus = false , bool autodestroy = true);
             static bool addAnimation(const std::string& client, double duration, std::map<std::string, RdkShellData> &animationProperties);
             static bool removeAnimation(const std::string& client);
             static bool addListener(const std::string& client, std::shared_ptr<RdkShellEventListener> listener);


### PR DESCRIPTION
From: kchinn681 kathiravan_chinnadurai@comcast.com

Subject: Crash observed when few plugins are activated from Controller UI in CMF-RPi
Reason for change:Crash observed when few plugins are activated from Controller UI in CMF-RPi
Test Procedure: activate html app using controller.ui
Risks: Low
Signed-off-by: kathiravan chinnadurai kathiravan_chinnadurai@comcast.com
Source: COMCAST
License: GPLV2
Upstream-Status: Pending