### PR TITLE
RDKTV-24799: WPEFramework crash with signature RdkShell::systemRam

### DIFF
--- a/rdkshell.cpp
+++ b/rdkshell.cpp
@@ -147,13 +147,14 @@ namespace RdkShell
                 {
                     readMemory = true;	
                     availableKb = atoll(token);
-                    break;
                 }
                 else
 		{
                     Logger::log(Debug, "failed to get memory details");
-                    break;
+		    fclose(file);
+		    return false;
                 }
+		break;
             }
         }
         if (!readMemory)


### PR DESCRIPTION
Reason for change: ensure closing file properly if memory extraction fails
Test Procedure: TBD
Risks: None
Priority: P1
signed-off-by: Ezhilarasi Velumani <Ezhilarasi_Velumani@.comcast.com>