### PR TITLE
RDKTV-24799: WPEFramework crash with signature RdkShell::systemRam

### DIFF
--- a/rdkshell.cpp
+++ b/rdkshell.cpp
@@ -128,7 +128,6 @@ namespace RdkShell
         if (!file)
         {
             Logger::log(Debug, "failed to get memory details");
-            fclose(file);
             return false;
         }
         char buffer[128];
@@ -147,13 +146,12 @@ namespace RdkShell
                 {
                     readMemory = true;	
                     availableKb = atoll(token);
-                    break;
                 }
                 else
 		{
                     Logger::log(Debug, "failed to get memory details");
-                    break;
                 }
+		break;
             }
         }
         if (!readMemory)


### PR DESCRIPTION
Reason for change: ensure closing file properly if memory extraction fails
Test Procedure: TBD
Risks: None
Priority: P1
Signed-off-by: Ezhilarasi Velumani <Ezhilarasi_Velumani@.comcast.com>