### PR TITLE
RDKTV-19422: Support for long key press using RDKShell

### DIFF
--- a/compositorcontroller.h
+++ b/compositorcontroller.h
@@ -68,6 +68,7 @@ namespace RdkShell
             static bool removeKeyMetadataListener(const std::string& client);
             static bool injectKey(const uint32_t& keyCode, const uint32_t& flags);
             static bool generateKey(const std::string& client, const uint32_t& keyCode, const uint32_t& flags, std::string virtualKey="");
+	    static bool generateKey(const std::string& client, const uint32_t& keyCode, const uint32_t& flags, std::string virtualKey, double duration);
             static bool getScreenResolution(uint32_t &width, uint32_t &height);
             static bool setScreenResolution(const uint32_t width, const uint32_t height);
             static bool getClients(std::vector<std::string>& clients);


### PR DESCRIPTION
Reason for change: Enabled support for long key press using RDKShell plugin.
Test Procedure: RDKShell.generateKey curl command with "duration" parameter in "Keys"
Risks: Low
Priority: P1
Signed-off-by: Ezhilarssi Velumani Ezhilarasi_Velumani@comcast.com