### PR TITLE
RDKDEV-990 - Upstream onApplicationFocusChanged event change handling

### DIFF
--- a/compositorcontroller.cpp
+++ b/compositorcontroller.cpp
@@ -408,6 +408,7 @@ namespace RdkShell
                   if (gRdkShellEventListener)
                   {
                       gRdkShellEventListener->onApplicationActivated(gFocusedCompositor.name);
+                      gRdkShellEventListener->onApplicationFocusChanged(gFocusedCompositor.name);
                   }
               }
           }
@@ -685,6 +686,7 @@ namespace RdkShell
         {
             client = gFocusedCompositor.name;
         }
+        Logger::log(LogLevel::Information,  "rdkshell_focus getFocused: the focus client is now %s", client.empty()?"none":client.c_str());
         return true;
     }
 
@@ -707,6 +709,10 @@ namespace RdkShell
 
             gFocusedCompositor = *it;
             gFocusedCompositor.compositor->setFocused(true);
+            if (gRdkShellEventListener)
+            {
+                gRdkShellEventListener->onApplicationFocusChanged(gFocusedCompositor.name);
+            }
             return true;
         }
         return false;
@@ -767,6 +773,10 @@ namespace RdkShell
                 // this may be changed to next available compositor
                 gFocusedCompositor.name = "";
                 gFocusedCompositor.compositor = nullptr;
+                if (gRdkShellEventListener)
+                {
+                    gRdkShellEventListener->onApplicationFocusChanged(gFocusedCompositor.name);
+                }
                 Logger::log(LogLevel::Information,  "rdkshell_focus kill: the focused client has been killed: %s.  there is no focused client.", clientDisplayName.c_str());
             }
             return true;
@@ -1544,6 +1554,10 @@ namespace RdkShell
             if ((!topmost && getNumCompositorInfo() == 0) || (topmost && focus))
             {
                 gFocusedCompositor = compositorInfo;
+                if (gRdkShellEventListener)
+                {
+                    gRdkShellEventListener->onApplicationFocusChanged(gFocusedCompositor.name);
+                }
                 Logger::log(LogLevel::Information,  "rdkshell_focus create: setting focus of first application created %s", gFocusedCompositor.name.c_str());
             }
 	    else if (focus)
@@ -1904,6 +1918,10 @@ namespace RdkShell
                 if ((!topmost && getNumCompositorInfo() == 0) || (topmost && focus))
                 {
                     gFocusedCompositor = compositorInfo;
+                    if (gRdkShellEventListener)
+                    {
+                        gRdkShellEventListener->onApplicationFocusChanged(gFocusedCompositor.name);
+                    }
                     Logger::log(LogLevel::Information,  "rdkshell_focus create: setting focus of first application created %s", gFocusedCompositor.name.c_str());
                 }
 

--- a/messageHandler.cpp
+++ b/messageHandler.cpp
@@ -105,6 +105,18 @@ void setFocusHandler(Document& d, uWS::WebSocket<uWS::SERVER> *ws)
   sendResponse(ws, ret);
 }
 
+void getFocusedHandler(Document &d, uWS::WebSocket<uWS::SERVER> *ws)
+{
+  std::string client("");
+
+  CompositorController::getFocused(client);
+  std::stringstream str("");
+  str<<"{\"params\":{";
+  str<<"\"client\":"<<client;
+  str<<"}}";
+  notifyClient(ws, (char*)str.str().c_str(), str.str().length(), uWS::OpCode::TEXT);
+}
+
 void killHandler(Document& d, uWS::WebSocket<uWS::SERVER> *ws)
 {
   std::string client("");
@@ -437,6 +449,7 @@ void MessageHandler::initMsgHandlers() {
   mHandlerMap["moveBehind"] = moveBehindHandler;
   mHandlerMap["setFocus"] = setFocusHandler;
   mHandlerMap["kill"] = killHandler;
+  mHandlerMap["getFocused"] = getFocusedHandler;
   mHandlerMap["addKeyIntercept"] = addKeyInterceptHandler;
   mHandlerMap["removeKeyIntercept"] = removeKeyInterceptHandler;
   mHandlerMap["getScreenResolution"] = getScreenResolutionHandler;

--- a/rdkshellevents.h
+++ b/rdkshellevents.h
@@ -38,6 +38,7 @@ namespace RdkShell
           virtual void onApplicationSuspended(const std::string& client) {}
           virtual void onApplicationResumed(const std::string& client) {}
           virtual void onApplicationActivated(const std::string& client) {}
+          virtual void onApplicationFocusChanged(const std::string& client) {}
           virtual void onUserInactive(const double minutes) {}
           virtual void onDeviceLowRamWarning(const int32_t freeKb, const int32_t availableKb, const int32_t usedSwapKb) {}
           virtual void onDeviceCriticallyLowRamWarning(const int32_t freeKb, const int32_t availableKb, const int32_t usedSwapKb) {}
@@ -58,6 +59,7 @@ namespace RdkShell
     const std::string RDKSHELL_EVENT_APPLICATION_SUSPENDED = "onApplicationSuspended";
     const std::string RDKSHELL_EVENT_APPLICATION_RESUMED = "onApplicationResumed";
     const std::string RDKSHELL_EVENT_APPLICATION_ACTIVATED = "onApplicationActivated";
+    const std::string RDKSHELL_EVENT_APPLICATION_FOCUSCHANGED = "onApplicationFocusChanged";
     const std::string RDKSHELL_EVENT_USER_INACTIVE = "onUserInactive";
     const std::string RDKSHELL_EVENT_DEVICE_LOW_RAM_WARNING = "onDeviceLowRamWarning";
     const std::string RDKSHELL_EVENT_DEVICE_CRITICALLY_LOW_RAM_WARNING = "onDeviceCriticallyLowRamWarning";


### PR DESCRIPTION
Reason for change: **onApplicationFocusChanged** event handling was not done, so added those changes for _getFocused_ and the corresponding event handlings.

Risks: Low

Test Procedure: Verified _wpeframework_ log; received _onApplicationFocusChanged_ events in the main UI; switched to YouTube and back to the main UI in all cases (when the focus changed).

Note: If any application requires this focus changed information, they can use it or ignore it. There are no issues.